### PR TITLE
Implement base app-gateway contract for frontend

### DIFF
--- a/generate_int_proto.sh
+++ b/generate_int_proto.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
+
+LIB_ROOT="/lib/"
+USER_ROOT="./int/hwsc-user-svc/proto/"
+DOCUMENT_ROOT="./int/hwsc-document-svc/proto/"
+FILE_ROOT="./int/hwsc-file-transaction-svc/proto"
+APP_ROOT="./int/hwsc-app-gateway-svc/proto/"
+
 # generate protoc for our service
 echo "Generating internal proto..."
-
 
 
 # SAMPLE SERVICE
@@ -10,57 +16,58 @@ echo "Generating hwsc-grpc-sample-svc.pb.go..."
 protoc int/hwsc-grpc-sample-svc/proto/hwsc-grpc-sample-svc.proto \
     --go_out=plugins=grpc:.
 
-
+echo "------------------------------------------------------------"
 
 # USER SERVICE
 echo "Generating hwsc-user-svc.pb.go, user.pb.go..."
-OUTPUT_ROOT="./int/hwsc-user-svc/proto/"
 protoc \
     -I ./lib/ \
-    -I ${OUTPUT_ROOT} \
-    --go_out=plugins=grpc:${OUTPUT_ROOT} \
+    -I ${USER_ROOT} \
+    --go_out=plugins=grpc:${USER_ROOT} \
     user.proto hwsc-user-svc.proto
 
-protoc-go-inject-tag -input=${OUTPUT_ROOT}hwsc-user-svc.pb.go
-protoc-go-inject-tag -input=${OUTPUT_ROOT}user.pb.go
-sed -i'.orig' -e 's/`json:"-"`/`json:"-" bson:"-"`/g' ${OUTPUT_ROOT}*.pb.go
+protoc-go-inject-tag -input=${USER_ROOT}hwsc-user-svc.pb.go
+protoc-go-inject-tag -input=${USER_ROOT}user.pb.go
+sed -i'.orig' -e 's/`json:"-"`/`json:"-" bson:"-"`/g' ${USER_ROOT}*.pb.go
 
-
+echo "------------------------------------------------------------"
 
 # DOCUMENT SERVICE
 echo "Generating hwsc-document-svc.pb.go, document.pb.go..."
-OUTPUT_ROOT="./int/hwsc-document-svc/proto/"
 protoc \
     -I ./lib/ \
-    -I ${OUTPUT_ROOT} \
-    --go_out=plugins=grpc:${OUTPUT_ROOT} \
+    -I ${DOCUMENT_ROOT} \
+    --go_out=plugins=grpc:${DOCUMENT_ROOT} \
     document.proto hwsc-document-svc.proto
 
-protoc-go-inject-tag -input=./int/hwsc-document-svc/proto/hwsc-document-svc.pb.go
-protoc-go-inject-tag -input=./int/hwsc-document-svc/proto/document.pb.go
+protoc-go-inject-tag -input=${DOCUMENT_ROOT}hwsc-document-svc.pb.go
+protoc-go-inject-tag -input=${DOCUMENT_ROOT}document.pb.go
 sed -i'.orig' -e 's/`json:"-"`/`json:"-" bson:"-"`/g' int/hwsc-document-svc/proto/*.pb.go
 sed -i'.orig' -e 's/json:"is_public,omitempty" bson:"isPublic"/json:"is_public" bson:"isPublic"/g' int/hwsc-document-svc/proto/*.pb.go
-
-
+#
+echo "------------------------------------------------------------"
 
 # FILE TRANSACTION SERVICE
 echo "Generating hwsc-file-transaction-svc.pb2.py, hwsc-file-transaction-svc.pb2_grpc.py..."
 python3 -m grpc_tools.protoc \
-    -I./int/hwsc-file-transaction-svc/proto \
+    -I ${FILE_ROOT} \
     --python_out=./int/hwsc-file-transaction-svc/proto/ \
     --grpc_python_out=./int/hwsc-file-transaction-svc/proto/ \
     ./int/hwsc-file-transaction-svc/proto/hwsc-file-transaction-svc.proto
 
-
+echo "------------------------------------------------------------"
 
 # APP GATEWAY SERVICE
 echo "Generating hwsc-app-gateway .ts, .js, .pb"
-OUTPUT_ROOT="./int/hwsc-app-gateway-svc/proto/"
 protoc \
   --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts \
   --plugin=protoc-gen-go=${GOPATH}/bin/protoc-gen-go \
-  -I ${OUTPUT_ROOT} \
-  --js_out=import_style=commonjs,binary:${OUTPUT_ROOT} \
-  --go_out=plugins=grpc:${OUTPUT_ROOT} \
-  --ts_out=service=true:${OUTPUT_ROOT} \
-  ${OUTPUT_ROOT}hwsc-app-gateway-svc.proto
+  -I ./lib/ \
+  -I ${USER_ROOT} \
+  -I ${DOCUMENT_ROOT} \
+  -I ${FILE_ROOT} \
+  -I ${APP_ROOT} \
+  --js_out=import_style=commonjs,binary:${APP_ROOT} \
+  --go_out=plugins=grpc:${APP_ROOT} \
+  --ts_out=service=true:${APP_ROOT} \
+  ${APP_ROOT}hwsc-app-gateway-svc.proto

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.pb.go
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.pb.go
@@ -22,12 +22,13 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-// data struct that accepts the follwogin
 type AppGatewayServiceRequest struct {
-	Message              string   `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+	UserRequest          *UserRequest     `protobuf:"bytes,1,opt,name=user_request,json=userRequest,proto3" json:"user_request,omitempty"`
+	DocumentRequest      *DocumentRequest `protobuf:"bytes,2,opt,name=document_request,json=documentRequest,proto3" json:"document_request,omitempty"`
+	Chunk                *Chunk           `protobuf:"bytes,3,opt,name=chunk,proto3" json:"chunk,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
+	XXX_unrecognized     []byte           `json:"-"`
+	XXX_sizecache        int32            `json:"-"`
 }
 
 func (m *AppGatewayServiceRequest) Reset()         { *m = AppGatewayServiceRequest{} }
@@ -55,21 +56,44 @@ func (m *AppGatewayServiceRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_AppGatewayServiceRequest proto.InternalMessageInfo
 
-func (m *AppGatewayServiceRequest) GetMessage() string {
+func (m *AppGatewayServiceRequest) GetUserRequest() *UserRequest {
 	if m != nil {
-		return m.Message
+		return m.UserRequest
 	}
-	return ""
+	return nil
+}
+
+func (m *AppGatewayServiceRequest) GetDocumentRequest() *DocumentRequest {
+	if m != nil {
+		return m.DocumentRequest
+	}
+	return nil
+}
+
+func (m *AppGatewayServiceRequest) GetChunk() *Chunk {
+	if m != nil {
+		return m.Chunk
+	}
+	return nil
 }
 
 type AppGatewayServiceResponse struct {
 	// Types that are valid to be assigned to Status:
 	//	*AppGatewayServiceResponse_Code
-	Status               isAppGatewayServiceResponse_Status `protobuf_oneof:"status"`
-	Message              string                             `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}                           `json:"-"`
-	XXX_unrecognized     []byte                             `json:"-"`
-	XXX_sizecache        int32                              `json:"-"`
+	Status  isAppGatewayServiceResponse_Status `protobuf_oneof:"status"`
+	Message string                             `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	User    *User                              `protobuf:"bytes,3,opt,name=user,proto3" json:"user,omitempty"`
+	// for ListUsers response
+	UserCollection []*User   `protobuf:"bytes,4,rep,name=user_collection,json=userCollection,proto3" json:"user_collection,omitempty"`
+	Document       *Document `protobuf:"bytes,5,opt,name=document,proto3" json:"document,omitempty"`
+	// Response for ListUserDocumentCollection
+	// Response for QueryDocument
+	DocumentCollection []*Document `protobuf:"bytes,6,rep,name=document_collection,json=documentCollection,proto3" json:"document_collection,omitempty"`
+	// Response for ListDistinctFieldValues
+	QueryResults         *QueryTransaction `protobuf:"bytes,7,opt,name=query_results,json=queryResults,proto3" json:"query_results,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
 }
 
 func (m *AppGatewayServiceResponse) Reset()         { *m = AppGatewayServiceResponse{} }
@@ -126,6 +150,41 @@ func (m *AppGatewayServiceResponse) GetMessage() string {
 		return m.Message
 	}
 	return ""
+}
+
+func (m *AppGatewayServiceResponse) GetUser() *User {
+	if m != nil {
+		return m.User
+	}
+	return nil
+}
+
+func (m *AppGatewayServiceResponse) GetUserCollection() []*User {
+	if m != nil {
+		return m.UserCollection
+	}
+	return nil
+}
+
+func (m *AppGatewayServiceResponse) GetDocument() *Document {
+	if m != nil {
+		return m.Document
+	}
+	return nil
+}
+
+func (m *AppGatewayServiceResponse) GetDocumentCollection() []*Document {
+	if m != nil {
+		return m.DocumentCollection
+	}
+	return nil
+}
+
+func (m *AppGatewayServiceResponse) GetQueryResults() *QueryTransaction {
+	if m != nil {
+		return m.QueryResults
+	}
+	return nil
 }
 
 // XXX_OneofFuncs is for the internal use of the proto package.
@@ -186,19 +245,43 @@ func init() {
 func init() { proto.RegisterFile("hwsc-app-gateway-svc.proto", fileDescriptor_1f25123fc1481ece) }
 
 var fileDescriptor_1f25123fc1481ece = []byte{
-	// 191 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xca, 0x28, 0x2f, 0x4e,
-	0xd6, 0x4d, 0x2c, 0x28, 0xd0, 0x4d, 0x4f, 0x2c, 0x49, 0x2d, 0x4f, 0xac, 0xd4, 0x2d, 0x2e, 0x4b,
-	0xd6, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x12, 0x04, 0xc9, 0x39, 0x16, 0x14, 0xb8, 0x43, 0x64,
-	0x82, 0xcb, 0x92, 0x95, 0x4c, 0xb8, 0x24, 0x90, 0x04, 0x52, 0x8b, 0xca, 0x32, 0x93, 0x53, 0x83,
-	0x52, 0x0b, 0x4b, 0x53, 0x8b, 0x4b, 0x84, 0x24, 0xb8, 0xd8, 0x73, 0x53, 0x8b, 0x8b, 0x13, 0xd3,
-	0x53, 0x25, 0x18, 0x15, 0x18, 0x35, 0x38, 0x83, 0x60, 0x5c, 0xa5, 0x50, 0x2e, 0x49, 0x2c, 0xba,
-	0x8a, 0x0b, 0xf2, 0xf3, 0x8a, 0x53, 0x85, 0x44, 0xb8, 0x58, 0x92, 0xf3, 0x53, 0x20, 0x7a, 0x78,
-	0x3d, 0x18, 0x82, 0xc0, 0x3c, 0x64, 0xc3, 0x98, 0x50, 0x0c, 0x73, 0xe2, 0xe0, 0x62, 0x2b, 0x2e,
-	0x49, 0x2c, 0x29, 0x2d, 0x36, 0xaa, 0xe5, 0x12, 0xc4, 0x30, 0x56, 0x28, 0x83, 0x8b, 0xd3, 0x3d,
-	0xb5, 0x24, 0x18, 0xac, 0x42, 0x48, 0x5b, 0x0f, 0xc3, 0x0b, 0x7a, 0xb8, 0xdc, 0x2f, 0xa5, 0x43,
-	0x9c, 0x62, 0x88, 0xb3, 0x95, 0x18, 0x9c, 0x84, 0xa3, 0x30, 0x03, 0x28, 0x89, 0x0d, 0x1c, 0x74,
-	0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x4a, 0x5a, 0x20, 0xf2, 0x58, 0x01, 0x00, 0x00,
+	// 562 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x56, 0x4d, 0x6f, 0xd3, 0x40,
+	0x10, 0xed, 0x47, 0x9a, 0x34, 0xd3, 0x26, 0x6d, 0x37, 0x88, 0x9a, 0x48, 0x40, 0x94, 0x13, 0x02,
+	0x92, 0x43, 0x73, 0xec, 0x01, 0xa5, 0x89, 0x1a, 0x24, 0xb8, 0xe0, 0x50, 0x0e, 0x5c, 0x2a, 0xb3,
+	0x9e, 0xd4, 0x16, 0x8e, 0xed, 0xee, 0x47, 0xaa, 0xfc, 0x4f, 0x2e, 0xfc, 0x0b, 0x7e, 0x02, 0xda,
+	0xd9, 0x38, 0x31, 0x0d, 0x48, 0x5c, 0xec, 0x53, 0x32, 0x3b, 0x6f, 0xdf, 0x9b, 0x37, 0x3b, 0x6b,
+	0x1b, 0xda, 0xc1, 0x83, 0xe4, 0x3d, 0x2f, 0x4d, 0x7b, 0x77, 0x9e, 0xc2, 0x07, 0x6f, 0xd9, 0x93,
+	0x0b, 0xde, 0x4f, 0x45, 0xa2, 0x12, 0x76, 0x66, 0x72, 0xc3, 0x34, 0x9d, 0xd8, 0xcc, 0x74, 0xc1,
+	0xdb, 0x2d, 0x82, 0x6b, 0x89, 0x62, 0x83, 0x6b, 0x83, 0x89, 0x57, 0xff, 0xcf, 0x09, 0xe0, 0x27,
+	0x5c, 0xcf, 0x31, 0x56, 0x39, 0x50, 0x33, 0x5b, 0x5b, 0xc5, 0x2f, 0x09, 0x38, 0x0b, 0x23, 0xec,
+	0x29, 0xe1, 0xc5, 0xd2, 0xe3, 0x2a, 0x4c, 0xe2, 0xcd, 0x86, 0xee, 0xcf, 0x5d, 0x70, 0x72, 0xe2,
+	0x28, 0x16, 0x21, 0x47, 0x17, 0xef, 0x35, 0x4a, 0xc5, 0x2e, 0xe1, 0xd8, 0x88, 0xde, 0x0a, 0x1b,
+	0x3b, 0xbb, 0x9d, 0xdd, 0x57, 0x47, 0x17, 0x4e, 0xdf, 0x90, 0xde, 0x48, 0x14, 0xd3, 0x05, 0xef,
+	0x9b, 0xdf, 0x15, 0xde, 0x3d, 0xd2, 0x9b, 0x80, 0x7d, 0x80, 0xd3, 0xac, 0x98, 0x35, 0xc1, 0x1e,
+	0x11, 0x74, 0x88, 0x60, 0xbc, 0x4a, 0x1a, 0x92, 0xec, 0x7f, 0x46, 0x74, 0xe2, 0xff, 0xb9, 0xc0,
+	0x06, 0x70, 0xc0, 0x03, 0x1d, 0x7f, 0x77, 0xf6, 0x89, 0xe1, 0x39, 0x31, 0x5c, 0x87, 0x11, 0x7e,
+	0xde, 0xb8, 0x32, 0x44, 0x23, 0x03, 0x72, 0x2d, 0xb6, 0xfb, 0x63, 0x0f, 0x9e, 0xfd, 0xc5, 0x9b,
+	0x4c, 0x93, 0x58, 0x22, 0x7b, 0x02, 0x15, 0x9e, 0xf8, 0x48, 0xa6, 0x1a, 0xef, 0x77, 0x5c, 0x8a,
+	0x98, 0x03, 0xb5, 0x39, 0x4a, 0xe9, 0xdd, 0x21, 0x15, 0x5b, 0x77, 0xb3, 0x90, 0xbd, 0x80, 0x8a,
+	0xb1, 0xb7, 0xaa, 0x00, 0xa8, 0x02, 0xeb, 0x9e, 0xd6, 0xd9, 0x00, 0x4e, 0xa8, 0x59, 0x3c, 0x89,
+	0x22, 0xa4, 0x82, 0x9c, 0x4a, 0x67, 0xff, 0x11, 0xb4, 0x69, 0x20, 0xa3, 0x35, 0x82, 0xbd, 0x86,
+	0xc3, 0xcc, 0xaa, 0x73, 0x40, 0xc4, 0x4d, 0x8b, 0x5e, 0x77, 0x64, 0x9d, 0x67, 0xef, 0xa0, 0xb5,
+	0x6e, 0x68, 0x4e, 0xa4, 0x4a, 0x22, 0x8f, 0xb7, 0xb1, 0x0c, 0x9a, 0x13, 0xbb, 0x84, 0xc6, 0xbd,
+	0x46, 0xb1, 0xbc, 0x15, 0x28, 0x75, 0xa4, 0xa4, 0x53, 0x23, 0xc5, 0xa7, 0x76, 0xeb, 0x27, 0x93,
+	0xca, 0xb5, 0xd3, 0x3d, 0x26, 0xb0, 0x6b, 0xb1, 0x57, 0x87, 0x50, 0x95, 0xca, 0x53, 0x5a, 0x5e,
+	0xfc, 0x6a, 0xc0, 0xd9, 0x56, 0x5b, 0x59, 0x00, 0xf5, 0x09, 0xaa, 0x29, 0x41, 0xd8, 0x9b, 0xfe,
+	0xd6, 0x50, 0xf7, 0xff, 0x35, 0x65, 0xed, 0xb7, 0xff, 0x07, 0xb6, 0xc7, 0xd6, 0xdd, 0x61, 0x21,
+	0xc0, 0x48, 0xa0, 0xa7, 0xd0, 0x74, 0xb4, 0x70, 0xa9, 0x31, 0x46, 0x58, 0x92, 0xd4, 0x4d, 0xea,
+	0x97, 0xe2, 0x2a, 0x81, 0xd3, 0xa1, 0x56, 0x01, 0xc6, 0x2a, 0xe4, 0xa5, 0x08, 0x06, 0x50, 0xff,
+	0x18, 0x4a, 0x65, 0x84, 0x0a, 0x9e, 0x8d, 0x19, 0xd4, 0x26, 0xa8, 0x8a, 0x77, 0x14, 0x41, 0x63,
+	0x1a, 0x78, 0x02, 0xb3, 0xfb, 0x56, 0xac, 0xda, 0x1c, 0x9a, 0x76, 0xe2, 0xcb, 0x91, 0x5b, 0x42,
+	0x3b, 0x3b, 0xae, 0xf1, 0xf6, 0x53, 0xa4, 0x68, 0xa7, 0xf6, 0x16, 0x94, 0xd6, 0x58, 0x7b, 0xbf,
+	0xcb, 0x91, 0x9b, 0x41, 0x6d, 0xe8, 0xfb, 0xe6, 0xb5, 0x55, 0xd2, 0x63, 0xab, 0x78, 0xa9, 0x05,
+	0x9c, 0x9b, 0x59, 0x19, 0x87, 0x52, 0x85, 0x31, 0x57, 0xd7, 0x21, 0x46, 0xfe, 0x17, 0x2f, 0xd2,
+	0x28, 0x0b, 0xbf, 0x80, 0xf4, 0xc2, 0x2a, 0xe5, 0xe0, 0xae, 0x5a, 0x5f, 0xb7, 0xbf, 0xd2, 0xbe,
+	0x55, 0xe9, 0x0b, 0x6a, 0xf0, 0x3b, 0x00, 0x00, 0xff, 0xff, 0xd4, 0xfa, 0xc5, 0x47, 0xdd, 0x09,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -213,9 +296,22 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type AppGatewayServiceClient interface {
-	// rpc == methods
-	// GetStatus accepts Request, returns response
 	GetStatus(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	CreateUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	DeleteUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	UpdateUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	AuthenticateUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	ListUsers(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	GetUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	ShareDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	CreateDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	ListUserDocumentCollection(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	UpdateDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	DeleteDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	AddFile(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	DeleteFile(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	ListDistinctFieldValues(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
+	QueryDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error)
 }
 
 type appGatewayServiceClient struct {
@@ -235,11 +331,159 @@ func (c *appGatewayServiceClient) GetStatus(ctx context.Context, in *AppGatewayS
 	return out, nil
 }
 
+func (c *appGatewayServiceClient) CreateUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/CreateUser", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) DeleteUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/DeleteUser", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) UpdateUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/UpdateUser", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) AuthenticateUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/AuthenticateUser", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) ListUsers(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/ListUsers", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) GetUser(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/GetUser", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) ShareDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/ShareDocument", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) CreateDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/CreateDocument", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) ListUserDocumentCollection(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/ListUserDocumentCollection", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) UpdateDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/UpdateDocument", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) DeleteDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/DeleteDocument", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) AddFile(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/AddFile", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) DeleteFile(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/DeleteFile", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) ListDistinctFieldValues(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/ListDistinctFieldValues", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *appGatewayServiceClient) QueryDocument(ctx context.Context, in *AppGatewayServiceRequest, opts ...grpc.CallOption) (*AppGatewayServiceResponse, error) {
+	out := new(AppGatewayServiceResponse)
+	err := c.cc.Invoke(ctx, "/hwscAppGatewaySvc.AppGatewayService/QueryDocument", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // AppGatewayServiceServer is the server API for AppGatewayService service.
 type AppGatewayServiceServer interface {
-	// rpc == methods
-	// GetStatus accepts Request, returns response
 	GetStatus(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	CreateUser(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	DeleteUser(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	UpdateUser(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	AuthenticateUser(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	ListUsers(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	GetUser(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	ShareDocument(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	CreateDocument(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	ListUserDocumentCollection(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	UpdateDocument(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	DeleteDocument(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	AddFile(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	DeleteFile(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	ListDistinctFieldValues(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
+	QueryDocument(context.Context, *AppGatewayServiceRequest) (*AppGatewayServiceResponse, error)
 }
 
 func RegisterAppGatewayServiceServer(s *grpc.Server, srv AppGatewayServiceServer) {
@@ -264,6 +508,276 @@ func _AppGatewayService_GetStatus_Handler(srv interface{}, ctx context.Context, 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _AppGatewayService_CreateUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).CreateUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/CreateUser",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).CreateUser(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_DeleteUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).DeleteUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/DeleteUser",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).DeleteUser(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_UpdateUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).UpdateUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/UpdateUser",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).UpdateUser(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_AuthenticateUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).AuthenticateUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/AuthenticateUser",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).AuthenticateUser(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_ListUsers_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).ListUsers(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/ListUsers",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).ListUsers(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_GetUser_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).GetUser(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/GetUser",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).GetUser(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_ShareDocument_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).ShareDocument(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/ShareDocument",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).ShareDocument(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_CreateDocument_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).CreateDocument(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/CreateDocument",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).CreateDocument(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_ListUserDocumentCollection_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).ListUserDocumentCollection(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/ListUserDocumentCollection",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).ListUserDocumentCollection(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_UpdateDocument_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).UpdateDocument(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/UpdateDocument",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).UpdateDocument(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_DeleteDocument_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).DeleteDocument(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/DeleteDocument",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).DeleteDocument(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_AddFile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).AddFile(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/AddFile",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).AddFile(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_DeleteFile_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).DeleteFile(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/DeleteFile",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).DeleteFile(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_ListDistinctFieldValues_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).ListDistinctFieldValues(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/ListDistinctFieldValues",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).ListDistinctFieldValues(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AppGatewayService_QueryDocument_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AppGatewayServiceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AppGatewayServiceServer).QueryDocument(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/hwscAppGatewaySvc.AppGatewayService/QueryDocument",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AppGatewayServiceServer).QueryDocument(ctx, req.(*AppGatewayServiceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _AppGatewayService_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "hwscAppGatewaySvc.AppGatewayService",
 	HandlerType: (*AppGatewayServiceServer)(nil),
@@ -271,6 +785,66 @@ var _AppGatewayService_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetStatus",
 			Handler:    _AppGatewayService_GetStatus_Handler,
+		},
+		{
+			MethodName: "CreateUser",
+			Handler:    _AppGatewayService_CreateUser_Handler,
+		},
+		{
+			MethodName: "DeleteUser",
+			Handler:    _AppGatewayService_DeleteUser_Handler,
+		},
+		{
+			MethodName: "UpdateUser",
+			Handler:    _AppGatewayService_UpdateUser_Handler,
+		},
+		{
+			MethodName: "AuthenticateUser",
+			Handler:    _AppGatewayService_AuthenticateUser_Handler,
+		},
+		{
+			MethodName: "ListUsers",
+			Handler:    _AppGatewayService_ListUsers_Handler,
+		},
+		{
+			MethodName: "GetUser",
+			Handler:    _AppGatewayService_GetUser_Handler,
+		},
+		{
+			MethodName: "ShareDocument",
+			Handler:    _AppGatewayService_ShareDocument_Handler,
+		},
+		{
+			MethodName: "CreateDocument",
+			Handler:    _AppGatewayService_CreateDocument_Handler,
+		},
+		{
+			MethodName: "ListUserDocumentCollection",
+			Handler:    _AppGatewayService_ListUserDocumentCollection_Handler,
+		},
+		{
+			MethodName: "UpdateDocument",
+			Handler:    _AppGatewayService_UpdateDocument_Handler,
+		},
+		{
+			MethodName: "DeleteDocument",
+			Handler:    _AppGatewayService_DeleteDocument_Handler,
+		},
+		{
+			MethodName: "AddFile",
+			Handler:    _AppGatewayService_AddFile_Handler,
+		},
+		{
+			MethodName: "DeleteFile",
+			Handler:    _AppGatewayService_DeleteFile_Handler,
+		},
+		{
+			MethodName: "ListDistinctFieldValues",
+			Handler:    _AppGatewayService_ListDistinctFieldValues_Handler,
+		},
+		{
+			MethodName: "QueryDocument",
+			Handler:    _AppGatewayService_QueryDocument_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.proto
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.proto
@@ -5,14 +5,28 @@ package hwscAppGatewaySvc;
 option go_package = "hwscAppGatewaySvc";
 
 service AppGatewayService {
-    // rpc == methods
-    // GetStatus accepts Request, returns response
     rpc GetStatus (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
-    rpc CreateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}g
+
+    // hwsc-user-svc
+    rpc CreateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc DeleteUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc UpdateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc AuthenticateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc ListUsers (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc GeteUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc ShareDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+
+    // hwsc-document-svc
+    rpc CreateDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc ListUserDocumentCollection (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc UpdateDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc DeleteDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc AddFileMetadata (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc DeleteFileMetadata (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc ListDistinctFieldValues (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc QueryDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
 }
 
-
-// data struct that accepts the follwogin
 message AppGatewayServiceRequest {
     string message = 1;
 }

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.proto
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.proto
@@ -8,6 +8,7 @@ service AppGatewayService {
     // rpc == methods
     // GetStatus accepts Request, returns response
     rpc GetStatus (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc CreateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}g
 }
 
 

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.proto
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc.proto
@@ -2,36 +2,53 @@ syntax="proto3";
 
 package hwscAppGatewaySvc;
 
+import "hwsc-user-svc.proto";
+import "user.proto";
+import "hwsc-document-svc.proto";
+import "document.proto";
+import "hwsc-file-transaction-svc.proto";
+
 option go_package = "hwscAppGatewaySvc";
 
 service AppGatewayService {
     rpc GetStatus (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
 
-    // hwsc-user-svc
     rpc CreateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc DeleteUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc UpdateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc AuthenticateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc ListUsers (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
-    rpc GeteUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc GetUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc ShareDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
 
-    // hwsc-document-svc
     rpc CreateDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc ListUserDocumentCollection (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc UpdateDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc DeleteDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
-    rpc AddFileMetadata (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
-    rpc DeleteFileMetadata (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc AddFile (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+    rpc DeleteFile (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc ListDistinctFieldValues (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
     rpc QueryDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
+
 }
 
 message AppGatewayServiceRequest {
-    string message = 1;
+    hwscUserSvc.UserRequest user_request = 1;
+    hwscDocumentSvc.DocumentRequest document_request = 2;
+    hwscFileTransactionSvc.Chunk chunk= 3;
 }
 
 message AppGatewayServiceResponse {
     oneof status { uint32 code = 1;}
     string message = 2;
+    hwsc.User user = 3;
+    // for ListUsers response
+    repeated hwsc.User user_collection = 4;
+
+    hwsc.Document document = 5;
+    // Response for ListUserDocumentCollection
+    // Response for QueryDocument
+    repeated hwsc.Document document_collection = 6;
+    // Response for ListDistinctFieldValues
+    hwsc.QueryTransaction query_results = 7;
 }

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb.d.ts
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb.d.ts
@@ -2,10 +2,27 @@
 // file: hwsc-app-gateway-svc.proto
 
 import * as jspb from "google-protobuf";
+import * as hwsc_user_svc_pb from "./hwsc-user-svc_pb";
+import * as user_pb from "./user_pb";
+import * as hwsc_document_svc_pb from "./hwsc-document-svc_pb";
+import * as document_pb from "./document_pb";
+import * as hwsc_file_transaction_svc_pb from "./hwsc-file-transaction-svc_pb";
 
 export class AppGatewayServiceRequest extends jspb.Message {
-  getMessage(): string;
-  setMessage(value: string): void;
+  hasUserRequest(): boolean;
+  clearUserRequest(): void;
+  getUserRequest(): hwsc_user_svc_pb.UserRequest | undefined;
+  setUserRequest(value?: hwsc_user_svc_pb.UserRequest): void;
+
+  hasDocumentRequest(): boolean;
+  clearDocumentRequest(): void;
+  getDocumentRequest(): hwsc_document_svc_pb.DocumentRequest | undefined;
+  setDocumentRequest(value?: hwsc_document_svc_pb.DocumentRequest): void;
+
+  hasChunk(): boolean;
+  clearChunk(): void;
+  getChunk(): hwsc_file_transaction_svc_pb.Chunk | undefined;
+  setChunk(value?: hwsc_file_transaction_svc_pb.Chunk): void;
 
   serializeBinary(): Uint8Array;
   toObject(includeInstance?: boolean): AppGatewayServiceRequest.AsObject;
@@ -19,7 +36,9 @@ export class AppGatewayServiceRequest extends jspb.Message {
 
 export namespace AppGatewayServiceRequest {
   export type AsObject = {
-    message: string,
+    userRequest?: hwsc_user_svc_pb.UserRequest.AsObject,
+    documentRequest?: hwsc_document_svc_pb.DocumentRequest.AsObject,
+    chunk?: hwsc_file_transaction_svc_pb.Chunk.AsObject,
   }
 }
 
@@ -31,6 +50,31 @@ export class AppGatewayServiceResponse extends jspb.Message {
 
   getMessage(): string;
   setMessage(value: string): void;
+
+  hasUser(): boolean;
+  clearUser(): void;
+  getUser(): user_pb.User | undefined;
+  setUser(value?: user_pb.User): void;
+
+  clearUserCollectionList(): void;
+  getUserCollectionList(): Array<user_pb.User>;
+  setUserCollectionList(value: Array<user_pb.User>): void;
+  addUserCollection(value?: user_pb.User, index?: number): user_pb.User;
+
+  hasDocument(): boolean;
+  clearDocument(): void;
+  getDocument(): document_pb.Document | undefined;
+  setDocument(value?: document_pb.Document): void;
+
+  clearDocumentCollectionList(): void;
+  getDocumentCollectionList(): Array<document_pb.Document>;
+  setDocumentCollectionList(value: Array<document_pb.Document>): void;
+  addDocumentCollection(value?: document_pb.Document, index?: number): document_pb.Document;
+
+  hasQueryResults(): boolean;
+  clearQueryResults(): void;
+  getQueryResults(): document_pb.QueryTransaction | undefined;
+  setQueryResults(value?: document_pb.QueryTransaction): void;
 
   getStatusCase(): AppGatewayServiceResponse.StatusCase;
   serializeBinary(): Uint8Array;
@@ -47,6 +91,11 @@ export namespace AppGatewayServiceResponse {
   export type AsObject = {
     code: number,
     message: string,
+    user?: user_pb.User.AsObject,
+    userCollectionList: Array<user_pb.User.AsObject>,
+    document?: document_pb.Document.AsObject,
+    documentCollectionList: Array<document_pb.Document.AsObject>,
+    queryResults?: document_pb.QueryTransaction.AsObject,
   }
 
   export enum StatusCase {

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb.js
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb.js
@@ -11,6 +11,11 @@ var jspb = require('google-protobuf');
 var goog = jspb;
 var global = Function('return this')();
 
+var hwsc$user$svc_pb = require('./hwsc-user-svc_pb.js');
+var user_pb = require('./user_pb.js');
+var hwsc$document$svc_pb = require('./hwsc-document-svc_pb.js');
+var document_pb = require('./document_pb.js');
+var hwsc$file$transaction$svc_pb = require('./hwsc-file-transaction-svc_pb.js');
 goog.exportSymbol('proto.hwscAppGatewaySvc.AppGatewayServiceRequest', null, global);
 goog.exportSymbol('proto.hwscAppGatewaySvc.AppGatewayServiceResponse', null, global);
 
@@ -60,7 +65,9 @@ proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.toObject = function(o
  */
 proto.hwscAppGatewaySvc.AppGatewayServiceRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
-    message: jspb.Message.getFieldWithDefault(msg, 1, "")
+    userRequest: (f = msg.getUserRequest()) && hwsc$user$svc_pb.UserRequest.toObject(includeInstance, f),
+    documentRequest: (f = msg.getDocumentRequest()) && hwsc$document$svc_pb.DocumentRequest.toObject(includeInstance, f),
+    chunk: (f = msg.getChunk()) && hwsc$file$transaction$svc_pb.Chunk.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -98,8 +105,19 @@ proto.hwscAppGatewaySvc.AppGatewayServiceRequest.deserializeBinaryFromReader = f
     var field = reader.getFieldNumber();
     switch (field) {
     case 1:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setMessage(value);
+      var value = new hwsc$user$svc_pb.UserRequest;
+      reader.readMessage(value,hwsc$user$svc_pb.UserRequest.deserializeBinaryFromReader);
+      msg.setUserRequest(value);
+      break;
+    case 2:
+      var value = new hwsc$document$svc_pb.DocumentRequest;
+      reader.readMessage(value,hwsc$document$svc_pb.DocumentRequest.deserializeBinaryFromReader);
+      msg.setDocumentRequest(value);
+      break;
+    case 3:
+      var value = new hwsc$file$transaction$svc_pb.Chunk;
+      reader.readMessage(value,hwsc$file$transaction$svc_pb.Chunk.deserializeBinaryFromReader);
+      msg.setChunk(value);
       break;
     default:
       reader.skipField();
@@ -130,28 +148,120 @@ proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.serializeBinary = fun
  */
 proto.hwscAppGatewaySvc.AppGatewayServiceRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
-  f = message.getMessage();
-  if (f.length > 0) {
-    writer.writeString(
+  f = message.getUserRequest();
+  if (f != null) {
+    writer.writeMessage(
       1,
-      f
+      f,
+      hwsc$user$svc_pb.UserRequest.serializeBinaryToWriter
+    );
+  }
+  f = message.getDocumentRequest();
+  if (f != null) {
+    writer.writeMessage(
+      2,
+      f,
+      hwsc$document$svc_pb.DocumentRequest.serializeBinaryToWriter
+    );
+  }
+  f = message.getChunk();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      hwsc$file$transaction$svc_pb.Chunk.serializeBinaryToWriter
     );
   }
 };
 
 
 /**
- * optional string message = 1;
- * @return {string}
+ * optional hwscUserSvc.UserRequest user_request = 1;
+ * @return {?proto.hwscUserSvc.UserRequest}
  */
-proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.getMessage = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.getUserRequest = function() {
+  return /** @type{?proto.hwscUserSvc.UserRequest} */ (
+    jspb.Message.getWrapperField(this, hwsc$user$svc_pb.UserRequest, 1));
 };
 
 
-/** @param {string} value */
-proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.setMessage = function(value) {
-  jspb.Message.setProto3StringField(this, 1, value);
+/** @param {?proto.hwscUserSvc.UserRequest|undefined} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.setUserRequest = function(value) {
+  jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.clearUserRequest = function() {
+  this.setUserRequest(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.hasUserRequest = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+/**
+ * optional hwscDocumentSvc.DocumentRequest document_request = 2;
+ * @return {?proto.hwscDocumentSvc.DocumentRequest}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.getDocumentRequest = function() {
+  return /** @type{?proto.hwscDocumentSvc.DocumentRequest} */ (
+    jspb.Message.getWrapperField(this, hwsc$document$svc_pb.DocumentRequest, 2));
+};
+
+
+/** @param {?proto.hwscDocumentSvc.DocumentRequest|undefined} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.setDocumentRequest = function(value) {
+  jspb.Message.setWrapperField(this, 2, value);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.clearDocumentRequest = function() {
+  this.setDocumentRequest(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.hasDocumentRequest = function() {
+  return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * optional hwscFileTransactionSvc.Chunk chunk = 3;
+ * @return {?proto.hwscFileTransactionSvc.Chunk}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.getChunk = function() {
+  return /** @type{?proto.hwscFileTransactionSvc.Chunk} */ (
+    jspb.Message.getWrapperField(this, hwsc$file$transaction$svc_pb.Chunk, 3));
+};
+
+
+/** @param {?proto.hwscFileTransactionSvc.Chunk|undefined} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.setChunk = function(value) {
+  jspb.Message.setWrapperField(this, 3, value);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.clearChunk = function() {
+  this.setChunk(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.hasChunk = function() {
+  return jspb.Message.getField(this, 3) != null;
 };
 
 
@@ -167,12 +277,19 @@ proto.hwscAppGatewaySvc.AppGatewayServiceRequest.prototype.setMessage = function
  * @constructor
  */
 proto.hwscAppGatewaySvc.AppGatewayServiceResponse = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, proto.hwscAppGatewaySvc.AppGatewayServiceResponse.oneofGroups_);
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.hwscAppGatewaySvc.AppGatewayServiceResponse.repeatedFields_, proto.hwscAppGatewaySvc.AppGatewayServiceResponse.oneofGroups_);
 };
 goog.inherits(proto.hwscAppGatewaySvc.AppGatewayServiceResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
   proto.hwscAppGatewaySvc.AppGatewayServiceResponse.displayName = 'proto.hwscAppGatewaySvc.AppGatewayServiceResponse';
 }
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.repeatedFields_ = [4,6];
+
 /**
  * Oneof group definitions for this message. Each group defines the field
  * numbers belonging to that group. When of these fields' value is set, all
@@ -228,7 +345,14 @@ proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.toObject = function(
 proto.hwscAppGatewaySvc.AppGatewayServiceResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     code: jspb.Message.getFieldWithDefault(msg, 1, 0),
-    message: jspb.Message.getFieldWithDefault(msg, 2, "")
+    message: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    user: (f = msg.getUser()) && user_pb.User.toObject(includeInstance, f),
+    userCollectionList: jspb.Message.toObjectList(msg.getUserCollectionList(),
+    user_pb.User.toObject, includeInstance),
+    document: (f = msg.getDocument()) && document_pb.Document.toObject(includeInstance, f),
+    documentCollectionList: jspb.Message.toObjectList(msg.getDocumentCollectionList(),
+    document_pb.Document.toObject, includeInstance),
+    queryResults: (f = msg.getQueryResults()) && document_pb.QueryTransaction.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -273,6 +397,31 @@ proto.hwscAppGatewaySvc.AppGatewayServiceResponse.deserializeBinaryFromReader = 
       var value = /** @type {string} */ (reader.readString());
       msg.setMessage(value);
       break;
+    case 3:
+      var value = new user_pb.User;
+      reader.readMessage(value,user_pb.User.deserializeBinaryFromReader);
+      msg.setUser(value);
+      break;
+    case 4:
+      var value = new user_pb.User;
+      reader.readMessage(value,user_pb.User.deserializeBinaryFromReader);
+      msg.addUserCollection(value);
+      break;
+    case 5:
+      var value = new document_pb.Document;
+      reader.readMessage(value,document_pb.Document.deserializeBinaryFromReader);
+      msg.setDocument(value);
+      break;
+    case 6:
+      var value = new document_pb.Document;
+      reader.readMessage(value,document_pb.Document.deserializeBinaryFromReader);
+      msg.addDocumentCollection(value);
+      break;
+    case 7:
+      var value = new document_pb.QueryTransaction;
+      reader.readMessage(value,document_pb.QueryTransaction.deserializeBinaryFromReader);
+      msg.setQueryResults(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -314,6 +463,46 @@ proto.hwscAppGatewaySvc.AppGatewayServiceResponse.serializeBinaryToWriter = func
     writer.writeString(
       2,
       f
+    );
+  }
+  f = message.getUser();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      user_pb.User.serializeBinaryToWriter
+    );
+  }
+  f = message.getUserCollectionList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      4,
+      f,
+      user_pb.User.serializeBinaryToWriter
+    );
+  }
+  f = message.getDocument();
+  if (f != null) {
+    writer.writeMessage(
+      5,
+      f,
+      document_pb.Document.serializeBinaryToWriter
+    );
+  }
+  f = message.getDocumentCollectionList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      6,
+      f,
+      document_pb.Document.serializeBinaryToWriter
+    );
+  }
+  f = message.getQueryResults();
+  if (f != null) {
+    writer.writeMessage(
+      7,
+      f,
+      document_pb.QueryTransaction.serializeBinaryToWriter
     );
   }
 };
@@ -360,6 +549,158 @@ proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.getMessage = functio
 /** @param {string} value */
 proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.setMessage = function(value) {
   jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional hwsc.User user = 3;
+ * @return {?proto.hwsc.User}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.getUser = function() {
+  return /** @type{?proto.hwsc.User} */ (
+    jspb.Message.getWrapperField(this, user_pb.User, 3));
+};
+
+
+/** @param {?proto.hwsc.User|undefined} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.setUser = function(value) {
+  jspb.Message.setWrapperField(this, 3, value);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.clearUser = function() {
+  this.setUser(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.hasUser = function() {
+  return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * repeated hwsc.User user_collection = 4;
+ * @return {!Array<!proto.hwsc.User>}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.getUserCollectionList = function() {
+  return /** @type{!Array<!proto.hwsc.User>} */ (
+    jspb.Message.getRepeatedWrapperField(this, user_pb.User, 4));
+};
+
+
+/** @param {!Array<!proto.hwsc.User>} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.setUserCollectionList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 4, value);
+};
+
+
+/**
+ * @param {!proto.hwsc.User=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.hwsc.User}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.addUserCollection = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 4, opt_value, proto.hwsc.User, opt_index);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.clearUserCollectionList = function() {
+  this.setUserCollectionList([]);
+};
+
+
+/**
+ * optional hwsc.Document document = 5;
+ * @return {?proto.hwsc.Document}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.getDocument = function() {
+  return /** @type{?proto.hwsc.Document} */ (
+    jspb.Message.getWrapperField(this, document_pb.Document, 5));
+};
+
+
+/** @param {?proto.hwsc.Document|undefined} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.setDocument = function(value) {
+  jspb.Message.setWrapperField(this, 5, value);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.clearDocument = function() {
+  this.setDocument(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.hasDocument = function() {
+  return jspb.Message.getField(this, 5) != null;
+};
+
+
+/**
+ * repeated hwsc.Document document_collection = 6;
+ * @return {!Array<!proto.hwsc.Document>}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.getDocumentCollectionList = function() {
+  return /** @type{!Array<!proto.hwsc.Document>} */ (
+    jspb.Message.getRepeatedWrapperField(this, document_pb.Document, 6));
+};
+
+
+/** @param {!Array<!proto.hwsc.Document>} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.setDocumentCollectionList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 6, value);
+};
+
+
+/**
+ * @param {!proto.hwsc.Document=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.hwsc.Document}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.addDocumentCollection = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 6, opt_value, proto.hwsc.Document, opt_index);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.clearDocumentCollectionList = function() {
+  this.setDocumentCollectionList([]);
+};
+
+
+/**
+ * optional hwsc.QueryTransaction query_results = 7;
+ * @return {?proto.hwsc.QueryTransaction}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.getQueryResults = function() {
+  return /** @type{?proto.hwsc.QueryTransaction} */ (
+    jspb.Message.getWrapperField(this, document_pb.QueryTransaction, 7));
+};
+
+
+/** @param {?proto.hwsc.QueryTransaction|undefined} value */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.setQueryResults = function(value) {
+  jspb.Message.setWrapperField(this, 7, value);
+};
+
+
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.clearQueryResults = function() {
+  this.setQueryResults(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.hwscAppGatewaySvc.AppGatewayServiceResponse.prototype.hasQueryResults = function() {
+  return jspb.Message.getField(this, 7) != null;
 };
 
 

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb_service.d.ts
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb_service.d.ts
@@ -13,9 +13,159 @@ type AppGatewayServiceGetStatus = {
   readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
 };
 
+type AppGatewayServiceCreateUser = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceDeleteUser = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceUpdateUser = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceAuthenticateUser = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceListUsers = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceGetUser = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceShareDocument = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceCreateDocument = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceListUserDocumentCollection = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceUpdateDocument = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceDeleteDocument = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceAddFile = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceDeleteFile = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceListDistinctFieldValues = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
+type AppGatewayServiceQueryDocument = {
+  readonly methodName: string;
+  readonly service: typeof AppGatewayService;
+  readonly requestStream: false;
+  readonly responseStream: false;
+  readonly requestType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceRequest;
+  readonly responseType: typeof hwsc_app_gateway_svc_pb.AppGatewayServiceResponse;
+};
+
 export class AppGatewayService {
   static readonly serviceName: string;
   static readonly GetStatus: AppGatewayServiceGetStatus;
+  static readonly CreateUser: AppGatewayServiceCreateUser;
+  static readonly DeleteUser: AppGatewayServiceDeleteUser;
+  static readonly UpdateUser: AppGatewayServiceUpdateUser;
+  static readonly AuthenticateUser: AppGatewayServiceAuthenticateUser;
+  static readonly ListUsers: AppGatewayServiceListUsers;
+  static readonly GetUser: AppGatewayServiceGetUser;
+  static readonly ShareDocument: AppGatewayServiceShareDocument;
+  static readonly CreateDocument: AppGatewayServiceCreateDocument;
+  static readonly ListUserDocumentCollection: AppGatewayServiceListUserDocumentCollection;
+  static readonly UpdateDocument: AppGatewayServiceUpdateDocument;
+  static readonly DeleteDocument: AppGatewayServiceDeleteDocument;
+  static readonly AddFile: AppGatewayServiceAddFile;
+  static readonly DeleteFile: AppGatewayServiceDeleteFile;
+  static readonly ListDistinctFieldValues: AppGatewayServiceListDistinctFieldValues;
+  static readonly QueryDocument: AppGatewayServiceQueryDocument;
 }
 
 export type ServiceError = { message: string, code: number; metadata: grpc.Metadata }
@@ -54,6 +204,141 @@ export class AppGatewayServiceClient {
     callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
   ): void;
   getStatus(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  createUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  createUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  deleteUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  deleteUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  updateUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  updateUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  authenticateUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  authenticateUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  listUsers(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  listUsers(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  getUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  getUser(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  shareDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  shareDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  createDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  createDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  listUserDocumentCollection(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  listUserDocumentCollection(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  updateDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  updateDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  deleteDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  deleteDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  addFile(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  addFile(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  deleteFile(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  deleteFile(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  listDistinctFieldValues(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  listDistinctFieldValues(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  queryDocument(
+    requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+    metadata: grpc.Metadata,
+    callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
+  ): void;
+  queryDocument(
     requestMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
     callback: (error: ServiceError|null, responseMessage: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse|null) => void
   ): void;

--- a/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb_service.js
+++ b/int/hwsc-app-gateway-svc/proto/hwsc-app-gateway-svc_pb_service.js
@@ -19,6 +19,141 @@ AppGatewayService.GetStatus = {
   responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
 };
 
+AppGatewayService.CreateUser = {
+  methodName: "CreateUser",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.DeleteUser = {
+  methodName: "DeleteUser",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.UpdateUser = {
+  methodName: "UpdateUser",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.AuthenticateUser = {
+  methodName: "AuthenticateUser",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.ListUsers = {
+  methodName: "ListUsers",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.GetUser = {
+  methodName: "GetUser",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.ShareDocument = {
+  methodName: "ShareDocument",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.CreateDocument = {
+  methodName: "CreateDocument",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.ListUserDocumentCollection = {
+  methodName: "ListUserDocumentCollection",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.UpdateDocument = {
+  methodName: "UpdateDocument",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.DeleteDocument = {
+  methodName: "DeleteDocument",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.AddFile = {
+  methodName: "AddFile",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.DeleteFile = {
+  methodName: "DeleteFile",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.ListDistinctFieldValues = {
+  methodName: "ListDistinctFieldValues",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
+AppGatewayService.QueryDocument = {
+  methodName: "QueryDocument",
+  service: AppGatewayService,
+  requestStream: false,
+  responseStream: false,
+  requestType: hwsc_app_gateway_svc_pb.AppGatewayServiceRequest,
+  responseType: hwsc_app_gateway_svc_pb.AppGatewayServiceResponse
+};
+
 exports.AppGatewayService = AppGatewayService;
 
 function AppGatewayServiceClient(serviceHost, options) {
@@ -31,6 +166,381 @@ AppGatewayServiceClient.prototype.getStatus = function getStatus(requestMessage,
     callback = arguments[1];
   }
   grpc.unary(AppGatewayService.GetStatus, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.createUser = function createUser(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.CreateUser, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.deleteUser = function deleteUser(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.DeleteUser, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.updateUser = function updateUser(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.UpdateUser, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.authenticateUser = function authenticateUser(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.AuthenticateUser, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.listUsers = function listUsers(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.ListUsers, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.getUser = function getUser(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.GetUser, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.shareDocument = function shareDocument(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.ShareDocument, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.createDocument = function createDocument(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.CreateDocument, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.listUserDocumentCollection = function listUserDocumentCollection(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.ListUserDocumentCollection, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.updateDocument = function updateDocument(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.UpdateDocument, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.deleteDocument = function deleteDocument(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.DeleteDocument, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.addFile = function addFile(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.AddFile, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.deleteFile = function deleteFile(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.DeleteFile, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.listDistinctFieldValues = function listDistinctFieldValues(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.ListDistinctFieldValues, {
+    request: requestMessage,
+    host: this.serviceHost,
+    metadata: metadata,
+    transport: this.options.transport,
+    debug: this.options.debug,
+    onEnd: function (response) {
+      if (callback) {
+        if (response.status !== grpc.Code.OK) {
+          var err = new Error(response.statusMessage);
+          err.code = response.status;
+          err.metadata = response.trailers;
+          callback(err, null);
+        } else {
+          callback(null, response.message);
+        }
+      }
+    }
+  });
+};
+
+AppGatewayServiceClient.prototype.queryDocument = function queryDocument(requestMessage, metadata, callback) {
+  if (arguments.length === 2) {
+    callback = arguments[1];
+  }
+  grpc.unary(AppGatewayService.QueryDocument, {
     request: requestMessage,
     host: this.serviceHost,
     metadata: metadata,


### PR DESCRIPTION
## Feature
https://github.com/hwsc-org/hwsc-app-gateway-svc/issues/9

Below are the initial expected services for the frontend.
These services are *NOT* the same with the other services.
### For example:
`rpc CreateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}` will use
hwsc-user-svc's `CreateUser` and hwsc-file-transaction-svc's `CreateUserFolder`
```
    rpc GetStatus (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc CreateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc DeleteUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc UpdateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc AuthenticateUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc ListUsers (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc GetUser (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc ShareDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc CreateDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc ListUserDocumentCollection (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc UpdateDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc DeleteDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc AddFile (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc DeleteFile (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc ListDistinctFieldValues (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
    rpc QueryDocument (AppGatewayServiceRequest) returns (AppGatewayServiceResponse) {}
```